### PR TITLE
perf: cache post snapshots during build

### DIFF
--- a/src/components/ui/cards/post-card.tsx
+++ b/src/components/ui/cards/post-card.tsx
@@ -25,7 +25,7 @@ export default function PostCard({
       <h2 className="text-3xl font-bold text-dracula-pink">{snapshot.title}</h2>
       <div className="flex flex-wrap gap-2">
         <DateTag lang={lang} date={snapshot.date} />
-        {snapshot.tags.sort().map((tag) => (
+        {[...snapshot.tags].sort().map((tag) => (
           <LabelTag lang={lang} label={tag} key={tag} />
         ))}
       </div>

--- a/src/components/ui/markdown-post.astro
+++ b/src/components/ui/markdown-post.astro
@@ -8,11 +8,11 @@ import Prose from "@/components/style/prose.astro";
 import TocCard from "./cards/toc-card.tsx";
 import { MISC } from "@/config";
 import { getUniqueLowerCaseTagMap } from "@/utils/post";
-import { render } from "astro:content";
 import { getDiffInDays } from "@/utils/date";
+import { getRenderedPost } from "@/utils/post-cache";
 
 const { lang, actualLang, post, headings } = Astro.props;
-const { Content } = await render(post);
+const { Content } = await getRenderedPost(post);
 
 let licenseEnabled = MISC.license?.enabled;
 if (post.data.license && post.data.license === "none") {

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -1,19 +1,17 @@
 ---
-import { getCollection } from "astro:content";
 import PostStack from "@/components/ui/post-stack";
 import BaseLayout from "@/layouts/base-layout.astro";
 import { supportedLangs } from "@/utils/i18n";
-import { getSnapshots } from "@/utils/post";
+import { getRankedSnapshotsForLang } from "@/utils/post-cache";
 import { MISC } from "@/config";
 
-const posts = await getCollection("posts");
-
-const { lang } = Astro.params;
-const snapshots = await getSnapshots(posts, lang);
+const { lang } = Astro.props;
+const snapshots = await getRankedSnapshotsForLang(lang);
 
 export function getStaticPaths() {
   return supportedLangs.map((lang) => ({
     params: { lang },
+    props: { lang },
   }));
 }
 ---

--- a/src/pages/[lang]/og-images/[slug].png.ts
+++ b/src/pages/[lang]/og-images/[slug].png.ts
@@ -1,11 +1,11 @@
 import type { APIRoute } from "astro";
 import { generateOgImageForPost } from "@/utils/og";
 import { getLangFromId, getSlugFromId } from "@/utils/post";
-import { getCollection } from "astro:content";
+import { getPosts } from "@/utils/post-cache";
 import type { Lang } from "@/utils/i18n";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("posts");
+  const posts = await getPosts();
 
   return posts.map((post) => ({
     params: {

--- a/src/pages/[lang]/posts/[slug].astro
+++ b/src/pages/[lang]/posts/[slug].astro
@@ -2,43 +2,36 @@
 import BaseLayout from "@/layouts/base-layout.astro";
 import MarkdownPost from "@/components/ui/markdown-post.astro";
 import TocCard from "@/components/ui/cards/toc-card";
-import { classifyByLangs, getLangFromId } from "@/utils/post";
-import { getCollection, getEntry } from "astro:content";
-import { getDescFromMdString } from "@/utils/markdown";
-import { render } from "astro:content";
-import { type Lang, supportedLangs } from "@/utils/i18n";
+import { classifyByLangs, getLangFromId, makeUniqueByLang } from "@/utils/post";
+import {
+  getPostDescription,
+  getPostHeadings,
+  getPosts,
+} from "@/utils/post-cache";
+import { supportedLangs } from "@/utils/i18n";
 
 export async function getStaticPaths() {
-  async function getPost(currentLang: Lang, slug: string) {
-    let post = await getEntry("posts", `${currentLang}/${slug}`);
-    if (!post) {
-      for (const possibleLang of supportedLangs) {
-        if (currentLang === possibleLang) continue;
-        post = await getEntry("posts", `${possibleLang}/${slug}`);
-        if (post) break;
-      }
-    }
-    return post!; // there should be a post at this point
-  }
-
-  const posts = await getCollection("posts");
+  const posts = await getPosts();
   const classified = classifyByLangs(posts);
   const paths = [];
 
-  for (const slug of classified.keys()) {
+  for (const [slug, postsWithSameSlug] of classified) {
     for (const lang of supportedLangs) {
-      const post = await getPost(lang, slug);
-      const headings = post ? (await render(post)).headings : [];
+      const post = makeUniqueByLang(postsWithSameSlug, lang)[0];
+      const [headings, description] = await Promise.all([
+        getPostHeadings(post),
+        getPostDescription(post),
+      ]);
       paths.push({
         params: { lang, slug },
-        props: { post, headings },
+        props: { post, headings, description },
       });
     }
   }
   return paths;
 }
 
-const { post, headings } = Astro.props;
+const { post, headings, description } = Astro.props;
 const { lang, slug } = Astro.params;
 const actualLangOfPost = getLangFromId(post.id);
 const ogImageUrlToUse =
@@ -47,7 +40,7 @@ const ogImageUrlToUse =
 
 <BaseLayout
   title={post!.data.title}
-  description={getDescFromMdString(post.body)}
+  description={description}
   ogImageUrl={ogImageUrlToUse}
   headerAsH1={false}
 >

--- a/src/pages/[lang]/posts/snapshots/[rank].json.ts
+++ b/src/pages/[lang]/posts/snapshots/[rank].json.ts
@@ -1,41 +1,25 @@
 import type { APIRoute } from "astro";
 
-import { getCollection } from "astro:content";
-import { getSnapshots } from "@/utils/post";
-import { type Lang, supportedLangs } from "@/utils/i18n";
+import { supportedLangs } from "@/utils/i18n";
+import { getRankedSnapshotsForLang } from "@/utils/post-cache";
 
-export const GET: APIRoute = async ({ params }) => {
-  const lang = params.lang as Lang;
-  const rank = Number(params.rank);
-
-  const posts = await getCollection("posts");
-  const snapshots = await getSnapshots(posts, lang);
-
-  return new Response(
-    JSON.stringify(
-      snapshots.map((snapshot, index) => ({ rank: index + 1, ...snapshot }))[
-        rank - 1
-      ]
-    )
-  );
+export const GET: APIRoute = async ({ props }) => {
+  return new Response(JSON.stringify(props.snapshot));
 };
 
 export async function getStaticPaths() {
-  const posts = await getCollection("posts");
-
-  const paths: { params: { lang: Lang; rank: string } }[] = [];
-
-  for (const lang of supportedLangs) {
-    const snapshots = await getSnapshots(posts, lang);
-    snapshots.forEach((_, index) => {
-      paths.push({
+  const paths = await Promise.all(
+    supportedLangs.map(async (lang) => {
+      const snapshots = await getRankedSnapshotsForLang(lang);
+      return snapshots.map((snapshot) => ({
         params: {
           lang,
-          rank: String(index + 1),
+          rank: String(snapshot.rank),
         },
-      });
-    });
-  }
+        props: { snapshot },
+      }));
+    })
+  );
 
-  return paths;
+  return paths.flat();
 }

--- a/src/pages/[lang]/posts/snapshots/index.json.ts
+++ b/src/pages/[lang]/posts/snapshots/index.json.ts
@@ -1,22 +1,17 @@
 import type { APIRoute } from "astro";
 
-import { getCollection } from "astro:content";
-import { getSnapshots } from "@/utils/post";
-import { type Lang, supportedLangs } from "@/utils/i18n";
+import { supportedLangs } from "@/utils/i18n";
+import { getRankedSnapshotsForLang } from "@/utils/post-cache";
 
-export const GET: APIRoute = async ({ params }) => {
-  const lang = params.lang as Lang;
-
-  const posts = await getCollection("posts");
-  const snapshots = await getSnapshots(posts, lang);
-
-  return new Response(
-    JSON.stringify(
-      snapshots.map((snapshot, index) => ({ rank: index + 1, ...snapshot }))
-    )
-  );
+export const GET: APIRoute = async ({ props }) => {
+  return new Response(JSON.stringify(props.snapshots));
 };
 
 export async function getStaticPaths() {
-  return supportedLangs.map((lang) => ({ params: { lang } }));
+  return Promise.all(
+    supportedLangs.map(async (lang) => ({
+      params: { lang },
+      props: { snapshots: await getRankedSnapshotsForLang(lang) },
+    }))
+  );
 }

--- a/src/pages/[lang]/tags/[tag].astro
+++ b/src/pages/[lang]/tags/[tag].astro
@@ -1,37 +1,29 @@
 ---
-import { getCollection } from "astro:content";
 import LabelTag from "@/components/ui/tags/label-tag";
 import PostStack from "@/components/ui/post-stack";
 import BaseLayout from "@/layouts/base-layout.astro";
 import { supportedLangs } from "@/utils/i18n";
 import { useTranslations } from "@/utils/i18n";
 import {
-  getSnapshots,
-  getUniqueLowerCaseTagMap,
-  makeUniqueByLang,
-} from "@/utils/post";
+  getRankedSnapshotsForTag,
+  getTagMapForLang,
+} from "@/utils/post-cache";
 
 export const getStaticPaths = async () => {
   const paths = await Promise.all(
     supportedLangs.map(async (lang) => {
-      const posts = await getCollection("posts");
-      const uniquePosts = makeUniqueByLang(posts, lang);
-      const tags = getUniqueLowerCaseTagMap(
-        uniquePosts.flatMap((uniquePost) => uniquePost.data.tags)
-      );
+      const tags = await getTagMapForLang(lang);
       return Array.from(tags.keys()).map((tag) => ({
         params: { lang, tag },
+        props: { lang, tag },
       }));
     })
   );
   return paths.flat();
 };
 
-const { lang, tag } = Astro.params;
-const filteredPosts = await getCollection("posts", (post) =>
-  getUniqueLowerCaseTagMap(post.data.tags).get(tag)
-);
-const filteredSnapshots = await getSnapshots(filteredPosts, lang);
+const { lang, tag } = Astro.props;
+const filteredSnapshots = await getRankedSnapshotsForTag(lang, tag);
 const t = useTranslations(lang);
 ---
 

--- a/src/pages/[lang]/tags/index.astro
+++ b/src/pages/[lang]/tags/index.astro
@@ -1,15 +1,11 @@
 ---
-import { getCollection } from "astro:content";
 import TagGroup from "@/components/ui/tag-group.tsx";
 import BaseLayout from "@/layouts/base-layout.astro";
 import { supportedLangs, useTranslations } from "@/utils/i18n";
-import { getSnapshots, getUniqueLowerCaseTagMap } from "@/utils/post";
+import { getTagMapForLang } from "@/utils/post-cache";
 
 const { lang } = Astro.props;
-const posts = await getCollection("posts");
-const tags = getUniqueLowerCaseTagMap(
-  (await getSnapshots(posts, lang)).flatMap((post) => post.tags)
-);
+const tags = await getTagMapForLang(lang);
 const t = useTranslations(lang);
 
 export function getStaticPaths() {

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,17 +1,29 @@
-import { getCollection } from "astro:content";
 import { SITE } from "@/config.ts";
 import { AUTHOR } from "@/config.ts";
 import type { Post } from "@/schemas/post";
 import { defaultLang } from "@/utils/i18n";
-import { getDescFromMdString } from "@/utils/markdown";
+import { getPostDescription, getPosts } from "@/utils/post-cache";
 import { getLangFromId, getSlugFromId } from "@/utils/post";
 
-function getLLMsTxt(
+async function getLLMsTxt(
   title: string,
   description: string,
   site: string,
   posts: Post[]
 ) {
+  const postItems = await Promise.all(
+    posts.map(async (post) => {
+      const lang = getLangFromId(post.id);
+      const slug = getSlugFromId(post.id);
+      const title = post.data.title;
+      const desc = await getPostDescription(post);
+      const pubDate = post.data.date;
+      const link = `${lang}/posts/${slug}`;
+      const tags = post.data.tags;
+      return `- [${title}](${link}): ${desc}\n  Published on ${pubDate}. Tags: ${tags.join(", ")}`;
+    })
+  );
+
   return `
 # ${title}
 
@@ -22,18 +34,7 @@ Author: ${AUTHOR.name}
 
 ## Posts
 
-${posts
-  .map((post) => {
-    const lang = getLangFromId(post.id);
-    const slug = getSlugFromId(post.id);
-    const title = post.data.title;
-    const desc = getDescFromMdString(post.body);
-    const pubDate = post.data.date;
-    const link = `${lang}/posts/${slug}`;
-    const tags = post.data.tags;
-    return `- [${title}](${link}): ${desc}\n  Published on ${pubDate}. Tags: ${tags.join(", ")}`;
-  })
-  .join("\n")}
+${postItems.join("\n")}
 
 ## Thanks
 
@@ -43,8 +44,8 @@ Powered by 🚀 [Astro](https://astro.build/)& ❤️ [AstroDraculaBlog](https:/
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 export async function GET(context: any) {
-  const posts = await getCollection("posts");
-  const llmsTxt = getLLMsTxt(
+  const posts = await getPosts();
+  const llmsTxt = await getLLMsTxt(
     SITE.title[defaultLang],
     SITE.description[defaultLang],
     context.site,

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -1,10 +1,10 @@
 ---
-import { getCollection } from "astro:content";
 import { defaultLang } from "@/utils/i18n";
 import { getLangFromId, getSlugFromId, makeUniqueByLang } from "@/utils/post";
+import { getPosts } from "@/utils/post-cache";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("posts");
+  const posts = await getPosts();
 
   const uniquePosts = makeUniqueByLang(posts, defaultLang);
   const paths = uniquePosts.map((post) => {

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,25 +1,20 @@
-import { getCollection } from "astro:content";
 import { SITE } from "@/config.ts";
 import { AUTHOR } from "@/config.ts";
-import type { Post } from "@/schemas/post";
 import { defaultLang } from "@/utils/i18n";
-import { getDescFromMdString } from "@/utils/markdown";
+import { getPostDescription, getPosts } from "@/utils/post-cache";
 import { getLangFromId, getSlugFromId } from "@/utils/post";
 import rss from "@astrojs/rss";
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 export async function GET(context: any) {
-  const posts = await getCollection("posts");
-  return rss({
-    title: SITE.title[defaultLang],
-    description: SITE.description[defaultLang],
-    site: context.site,
-    items: posts.map((post: Post) => {
+  const posts = await getPosts();
+  const items = await Promise.all(
+    posts.map(async (post) => {
       const lang = getLangFromId(post.id);
       const slug = getSlugFromId(post.id);
       return {
         title: post.data.title,
-        description: getDescFromMdString(post.body),
+        description: await getPostDescription(post),
         author: AUTHOR.name,
         pubDate: post.data.date,
         link: `${lang}/posts/${slug}`,
@@ -29,7 +24,14 @@ export async function GET(context: any) {
           type: "image/png",
         },
       };
-    }),
+    })
+  );
+
+  return rss({
+    title: SITE.title[defaultLang],
+    description: SITE.description[defaultLang],
+    site: context.site,
+    items,
     stylesheet: "/rss.xsl",
   });
 }

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,14 +1,9 @@
 ---
-import { getCollection } from "astro:content";
 import { defaultLang, useTranslatedPath } from "@/utils/i18n";
-import { getUniqueLowerCaseTagMap, makeUniqueByLang } from "@/utils/post";
+import { getTagMapForLang } from "@/utils/post-cache";
 
 export const getStaticPaths = async () => {
-  const posts = await getCollection("posts");
-  const uniquePosts = makeUniqueByLang(posts, defaultLang);
-  const tags = getUniqueLowerCaseTagMap(
-    uniquePosts.flatMap((uniquePost) => uniquePost.data.tags)
-  );
+  const tags = await getTagMapForLang(defaultLang);
   return Array.from(tags.keys()).map((tag) => ({ params: { tag } }));
 };
 

--- a/src/schemas/post.ts
+++ b/src/schemas/post.ts
@@ -27,6 +27,11 @@ export const PostSnapshotSchema = z.object({
   date: z.string(),
 });
 
+export const RankedPostSnapshotSchema = PostSnapshotSchema.extend({
+  rank: z.number(),
+});
+
 export type PostFrontmatter = z.infer<typeof PostFrontmatterSchema>;
 export type PostSnapshot = z.infer<typeof PostSnapshotSchema>;
+export type RankedPostSnapshot = z.infer<typeof RankedPostSnapshotSchema>;
 export type Post = CollectionEntry<"posts">;

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,20 +1,34 @@
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { toString as mdastToString } from "mdast-util-to-string";
 
+import { MISC } from "../config";
+
+function getFirstMoreMarkIndex(mdString: string) {
+  const indexes = MISC.more.marks
+    .map((mark) => mdString.indexOf(mark))
+    .filter((index) => index >= 0);
+
+  return indexes.length > 0 ? Math.min(...indexes) : -1;
+}
+
+function sliceAtFirstMoreMark(mdString: string) {
+  const moreMarkIndex = getFirstMoreMarkIndex(mdString);
+  return moreMarkIndex >= 0 ? mdString.slice(0, moreMarkIndex) : mdString;
+}
+
 export function getDescFromMdString(mdString: string | undefined) {
   if (!mdString) {
     return "";
   }
-  const mdast = fromMarkdown(mdString);
-  const desc = mdastToString(mdast);
-  const pos = desc.indexOf("<!--more-->");
-  return desc.slice(0, pos);
+
+  const mdast = fromMarkdown(sliceAtFirstMoreMark(mdString));
+  return mdastToString(mdast);
 }
 
 export function remarkDescPlugin() {
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   return (tree: any, { data }: any) => {
     const textOnPage = mdastToString(tree);
-    data.astro.frontmatter.desc = getDescFromMdString(textOnPage);
+    data.astro.frontmatter.desc = sliceAtFirstMoreMark(textOnPage);
   };
 }

--- a/src/utils/post-cache.ts
+++ b/src/utils/post-cache.ts
@@ -4,7 +4,7 @@ import { getCollection, render } from "astro:content";
 import type { Lang } from "@/utils/i18n";
 import { getDescFromMdString } from "@/utils/markdown";
 import { getSnapshots, getUniqueLowerCaseTagMap } from "@/utils/post";
-import type { Post, RankedPostSnapshot } from "@/schemas/post";
+import type { Post, PostSnapshot, RankedPostSnapshot } from "@/schemas/post";
 
 type RenderedPost = Awaited<ReturnType<typeof render>>;
 
@@ -35,7 +35,7 @@ function getOrCreatePromise<K, V>(
   return promise;
 }
 
-function rankSnapshots(snapshots: Omit<RankedPostSnapshot, "rank">[]) {
+function rankSnapshots(snapshots: PostSnapshot[]): RankedPostSnapshot[] {
   return snapshots.map((snapshot, index) => ({
     rank: index + 1,
     ...snapshot,

--- a/src/utils/post-cache.ts
+++ b/src/utils/post-cache.ts
@@ -1,0 +1,103 @@
+import type { MarkdownHeading } from "astro";
+import { getCollection, render } from "astro:content";
+
+import type { Lang } from "@/utils/i18n";
+import { getDescFromMdString } from "@/utils/markdown";
+import { getSnapshots, getUniqueLowerCaseTagMap } from "@/utils/post";
+import type { Post, RankedPostSnapshot } from "@/schemas/post";
+
+type RenderedPost = Awaited<ReturnType<typeof render>>;
+
+const rankedSnapshotsByLang = new Map<Lang, Promise<RankedPostSnapshot[]>>();
+const rankedSnapshotsByLangAndTag = new Map<
+  string,
+  Promise<RankedPostSnapshot[]>
+>();
+const postDescriptions = new Map<string, Promise<string>>();
+const postRenderResults = new Map<string, Promise<RenderedPost>>();
+const tagMapsByLang = new Map<Lang, Promise<Map<string, number>>>();
+
+let postsPromise: Promise<Post[]> | undefined;
+
+function getOrCreatePromise<K, V>(
+  cache: Map<K, Promise<V>>,
+  key: K,
+  create: () => Promise<V>
+) {
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  const promise = create().catch((error) => {
+    cache.delete(key);
+    throw error;
+  });
+  cache.set(key, promise);
+  return promise;
+}
+
+function rankSnapshots(snapshots: Omit<RankedPostSnapshot, "rank">[]) {
+  return snapshots.map((snapshot, index) => ({
+    rank: index + 1,
+    ...snapshot,
+  }));
+}
+
+export function getPosts() {
+  if (!postsPromise) {
+    postsPromise = getCollection("posts").catch((error) => {
+      postsPromise = undefined;
+      throw error;
+    });
+  }
+
+  return postsPromise;
+}
+
+export function getPostDescription(post: Post) {
+  return getOrCreatePromise(postDescriptions, post.id, async () =>
+    getDescFromMdString(post.body)
+  );
+}
+
+export function getRenderedPost(post: Post) {
+  return getOrCreatePromise(postRenderResults, post.id, () => render(post));
+}
+
+export async function getPostHeadings(post: Post): Promise<MarkdownHeading[]> {
+  const { headings } = await getRenderedPost(post);
+  return headings;
+}
+
+export function getRankedSnapshotsForLang(lang: Lang) {
+  return getOrCreatePromise(rankedSnapshotsByLang, lang, async () => {
+    const posts = await getPosts();
+    const snapshots = await getSnapshots(posts, lang, getPostDescription);
+    return rankSnapshots(snapshots);
+  });
+}
+
+export function getRankedSnapshotsForTag(lang: Lang, tag: string) {
+  const key = `${lang}\0${tag}`;
+
+  return getOrCreatePromise(rankedSnapshotsByLangAndTag, key, async () => {
+    const posts = await getPosts();
+    const filteredPosts = posts.filter((post) =>
+      getUniqueLowerCaseTagMap(post.data.tags).has(tag)
+    );
+    const snapshots = await getSnapshots(
+      filteredPosts,
+      lang,
+      getPostDescription
+    );
+    return rankSnapshots(snapshots);
+  });
+}
+
+export function getTagMapForLang(lang: Lang) {
+  return getOrCreatePromise(tagMapsByLang, lang, async () => {
+    const snapshots = await getRankedSnapshotsForLang(lang);
+    return getUniqueLowerCaseTagMap(
+      snapshots.flatMap((snapshot) => snapshot.tags)
+    );
+  });
+}

--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -61,31 +61,37 @@ export const makeUniqueByLang = (posts: Post[], expectedLang: Lang) => {
 /**
  * Gets the snapshots of posts. They are unique to languages, and sorted by date.
  */
+type PostDescriptionGetter = (post: Post) => string | Promise<string>;
+
 export const getSnapshots = async (
   posts: Post[],
-  expectedLang: Lang
+  expectedLang: Lang,
+  getPostDescription: PostDescriptionGetter = (post) =>
+    getDescFromMdString(post.body)
 ): Promise<PostSnapshot[]> => {
   const uniquePosts = makeUniqueByLang(posts, expectedLang);
-  const sorted = uniquePosts.sort((a, b) => {
+  const sorted = [...uniquePosts].sort((a, b) => {
     const dateA = a.data.updated || a.data.date;
     const dateB = b.data.updated || b.data.date;
     return dateB.getTime() - dateA.getTime();
   });
-  return sorted.map((post) => {
-    const slug = getSlugFromId(post.id);
+  return Promise.all(
+    sorted.map(async (post) => {
+      const slug = getSlugFromId(post.id);
 
-    return {
-      href: `/${expectedLang}/posts/${slug}`,
-      title: post.data.title,
-      date: getCloserFormattedDate(
-        post.data.updated?.toISOString(),
-        post.data.date.toISOString()
-      )!,
-      description: getDescFromMdString(post.body),
-      slug,
-      tags: Array.from(getUniqueLowerCaseTagMap(post.data.tags).keys()),
-    };
-  });
+      return {
+        href: `/${expectedLang}/posts/${slug}`,
+        title: post.data.title,
+        date: getCloserFormattedDate(
+          post.data.updated?.toISOString(),
+          post.data.date.toISOString()
+        )!,
+        description: await getPostDescription(post),
+        slug,
+        tags: Array.from(getUniqueLowerCaseTagMap(post.data.tags).keys()),
+      };
+    })
+  );
 };
 
 /**


### PR DESCRIPTION
## Summary
- add a build-time post cache for posts, ranked snapshots, descriptions, tag maps, and rendered posts
- reuse cached ranked snapshots in per-rank and index snapshot JSON routes
- optimize Markdown description extraction by slicing at `<!--more-->` before parsing
- reuse cached post data across index, tag, RSS, llms.txt, post, and OG routes

## Test Plan
- pnpm exec astro check
- pnpm lint
- pnpm format:check
- pnpm build

## Notes
- Keeps the existing per-rank JSON API unchanged.
- Build logs show snapshot JSON pages are now generated in ~0-1ms each instead of 100-200ms.