### PR TITLE
Add post language fallback and SEO meta tags

### DIFF
--- a/src/components/head/meta.astro
+++ b/src/components/head/meta.astro
@@ -2,33 +2,73 @@
 import { SITE } from "@/config";
 import type { Lang } from "@/utils/i18n";
 
-const { lang, description, pageTitle, ogImageUrl } = Astro.props;
+const {
+  lang,
+  description,
+  pageTitle,
+  ogImageUrl,
+  canonicalPath,
+  noindex = false,
+  ogLocaleLang,
+  alternateLangs = [],
+  alternatePath,
+} = Astro.props;
 const pageDescription = description || SITE.description[lang as Lang];
 const pageOgDomain = Astro.url.hostname;
-const pageOgUrl = Astro.url.href;
+const canonicalUrl = new URL(canonicalPath || Astro.url.pathname, SITE.url);
+const canonicalHref = canonicalUrl.href;
 const pageOgImageUrl = new URL(ogImageUrl || SITE.og.imageUrl, Astro.url);
+const ogLocaleMap: Record<Lang, string> = {
+  en: "en_US",
+  zh: "zh_CN",
+};
+const localeLang = (ogLocaleLang || lang) as Lang;
+type AlternateLink = { lang: Lang; href: string };
+
+const alternateLinks: AlternateLink[] = alternateLangs.map((alternateLang: Lang) => ({
+  lang: alternateLang,
+  href: new URL(alternatePath(alternateLang), SITE.url).href,
+}));
+const xDefaultHref = alternateLinks[0]?.href;
+const alternateLocales = alternateLangs.filter(
+  (alternateLang: Lang) => alternateLang !== localeLang
+);
 ---
 
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />
 <meta name="generator" content={Astro.generator} />
 <meta name="description" content={pageDescription} />
+<link rel="canonical" href={canonicalHref} />
+{noindex && <meta name="robots" content="noindex, follow" />}
+{
+  alternateLinks.map(({ lang, href }: AlternateLink) => (
+    <link rel="alternate" hreflang={lang} href={href} />
+  ))
+}
+{xDefaultHref && <link rel="alternate" hreflang="x-default" href={xDefaultHref} />}
 <meta name="msvalidate.01" content={SITE.searchEngine.bing} />
 <meta name="baidu-site-verification" content={SITE.searchEngine.baidu} />
 <meta name="sogou_site_verification" content={SITE.searchEngine.sogou} />
 <meta name="360-site-verification" content={SITE.searchEngine.threeSixZero} />
 
 <!-- Facebook Meta Tags -->
-<meta property="og:url" content={pageOgUrl} />
+<meta property="og:url" content={canonicalHref} />
 <meta property="og:type" content="website" />
 <meta property="og:title" content={pageTitle} />
 <meta property="og:description" content={pageDescription} />
 <meta property="og:image" content={pageOgImageUrl} />
+<meta property="og:locale" content={ogLocaleMap[localeLang]} />
+{
+  alternateLocales.map((alternateLang: Lang) => (
+    <meta property="og:locale:alternate" content={ogLocaleMap[alternateLang]} />
+  ))
+}
 
 <!-- Twitter Meta Tags -->
 <meta name="twitter:card" content="summary_large_image" />
 <meta property="twitter:domain" content={pageOgDomain} />
-<meta property="twitter:url" content={pageOgUrl} />
+<meta property="twitter:url" content={canonicalHref} />
 <meta name="twitter:title" content={pageTitle} />
 <meta name="twitter:description" content={pageDescription} />
 <meta name="twitter:image" content={pageOgImageUrl} />

--- a/src/components/ui/cards/post-card.tsx
+++ b/src/components/ui/cards/post-card.tsx
@@ -1,5 +1,6 @@
 import DateTag from "@/components/ui/tags/date-tag";
 import LabelTag from "@/components/ui/tags/label-tag";
+import NotSupportedLangTag from "@/components/ui/tags/not-supported-lang-tag";
 import type { Lang } from "@/utils/i18n";
 import type { PostSnapshot } from "@/schemas/post";
 import { motion } from "motion/react";
@@ -13,11 +14,9 @@ export default function PostCard({
   snapshot: PostSnapshot;
   animate?: boolean;
 }) {
-  const shouldReduceMotion = false;
-  const initialOpacity = shouldReduceMotion ? 1 : 0;
-  const initialX = shouldReduceMotion ? 0 : 10;
+  const sortedTags = [...snapshot.tags].sort();
 
-  const component = (
+  const card = (
     <a
       href={snapshot.href}
       className="flex card-hoverable flex-col gap-4 p-8 text-pretty"
@@ -25,7 +24,8 @@ export default function PostCard({
       <h2 className="text-3xl font-bold text-dracula-pink">{snapshot.title}</h2>
       <div className="flex flex-wrap gap-2">
         <DateTag lang={lang} date={snapshot.date} />
-        {[...snapshot.tags].sort().map((tag) => (
+        {snapshot.isFallback && <NotSupportedLangTag lang={lang} />}
+        {sortedTags.map((tag) => (
           <LabelTag lang={lang} label={tag} key={tag} />
         ))}
       </div>
@@ -36,12 +36,12 @@ export default function PostCard({
   );
   return animate ? (
     <motion.div
-      initial={{ opacity: initialOpacity, x: initialX }}
+      initial={{ opacity: 0, x: 10 }}
       whileInView={{ opacity: 1, x: 0 }}
     >
-      {component}
+      {card}
     </motion.div>
   ) : (
-    component
+    card
   );
 }

--- a/src/components/ui/language-picker.astro
+++ b/src/components/ui/language-picker.astro
@@ -1,6 +1,10 @@
 ---
-import { languages } from "@/utils/i18n";
-import { getLangFromUrl, useTranslatedPath } from "@/utils/i18n";
+import {
+  getLangFromUrl,
+  languages,
+  supportedLangs,
+  useTranslatedPath,
+} from "@/utils/i18n";
 
 const [activeLang, urlWithoutLang] = getLangFromUrl(Astro.url.pathname);
 const translatePath = useTranslatedPath(activeLang);
@@ -8,17 +12,17 @@ const translatePath = useTranslatedPath(activeLang);
 
 <ul class="flex gap-2">
   {
-    Object.entries(languages).map(([lang, label]) => (
+    supportedLangs.map((lang) => (
       <li>
         <a
-          href={translatePath(`/${urlWithoutLang}`, lang)}
+          href={translatePath(urlWithoutLang, lang)}
           class={
             lang === activeLang
               ? "text-dracula-purple underline underline-offset-4"
               : "text-dracula-purple/80 underline underline-offset-4 transition hover:text-dracula-purple"
           }
         >
-          {label}
+          {languages[lang]}
         </a>
       </li>
     ))

--- a/src/components/ui/markdown-post.astro
+++ b/src/components/ui/markdown-post.astro
@@ -14,10 +14,7 @@ import { getRenderedPost } from "@/utils/post-cache";
 const { lang, actualLang, post, headings } = Astro.props;
 const { Content } = await getRenderedPost(post);
 
-let licenseEnabled = MISC.license?.enabled;
-if (post.data.license && post.data.license === "none") {
-  licenseEnabled = false;
-}
+const licenseEnabled = MISC.license?.enabled && post.data.license !== "none";
 const license = post.data.license || MISC.license.default.name;
 const licenseLink = post.data.licenseLink || MISC.license.default.link;
 const title = post.data.title;
@@ -27,10 +24,9 @@ const latestDate = updatedAt || publishedAt;
 const diffInDays = getDiffInDays(new Date(), latestDate);
 ---
 
-<article>
+<article lang={actualLang}>
   <h1 class="text-4xl font-black text-dracula-pink">{title}</h1>
   <div class="mt-4 flex flex-wrap gap-2">
-    <!-- date tags -->
     <DateTag lang={lang} date={publishedAt} type="published" client:load />
     {
       updatedAt && (
@@ -39,10 +35,8 @@ const diffInDays = getDiffInDays(new Date(), latestDate);
     }
     <DateStatusTag lang={lang} diffInDays={diffInDays} client:load />
 
-    <!-- language tag -->
     {lang !== actualLang && <NotSupportedLangTag lang={lang} client:load />}
 
-    <!-- license tag -->
     {
       licenseEnabled && (
         <LicenseTag
@@ -54,7 +48,6 @@ const diffInDays = getDiffInDays(new Date(), latestDate);
       )
     }
 
-    <!-- label tags -->
     {
       Array.from(getUniqueLowerCaseTagMap(post.data.tags).keys()).map((tag) => (
         <LabelTag lang={lang} label={tag} type="link" client:load />
@@ -79,14 +72,14 @@ const diffInDays = getDiffInDays(new Date(), latestDate);
 
 <script>
   const copyButtonLabel = "Copy";
-  const codeBlocks = Array.from(document.querySelectorAll("pre"));
+  const codeBlocks = document.querySelectorAll<HTMLElement>("pre");
 
   for (const codeBlock of codeBlocks) {
     const wrapper = document.createElement("div");
     wrapper.style.position = "relative";
     const copyButton = document.createElement("button");
     copyButton.className = "copy-code";
-    copyButton.innerHTML = copyButtonLabel;
+    copyButton.textContent = copyButtonLabel;
 
     codeBlock.setAttribute("tabindex", "0");
     codeBlock.appendChild(copyButton);
@@ -94,21 +87,21 @@ const diffInDays = getDiffInDays(new Date(), latestDate);
     codeBlock.parentNode!.insertBefore(wrapper, codeBlock);
     wrapper.appendChild(codeBlock);
 
-    copyButton.addEventListener("click", async () => {
-      await copyCode(codeBlock, copyButton);
+    copyButton.addEventListener("click", () => {
+      copyCode(codeBlock, copyButton);
     });
   }
 
   async function copyCode(block: HTMLElement, button: HTMLElement) {
     const code = block.querySelector("code");
-    const text = code?.innerText || "";
+    const text = code?.innerText ?? "";
 
     await navigator.clipboard.writeText(text);
 
-    button.innerText = "Copied";
+    button.textContent = "Copied";
 
     setTimeout(() => {
-      button.innerText = copyButtonLabel;
+      button.textContent = copyButtonLabel;
     }, 1000);
   }
 </script>

--- a/src/components/ui/tags/not-supported-lang-tag.tsx
+++ b/src/components/ui/tags/not-supported-lang-tag.tsx
@@ -1,11 +1,12 @@
 import { type Lang, useTranslations } from "@/utils/i18n";
 import BaseTag from "./base-tag";
 
-export default function LicenseTag({ lang }: { lang: Lang }) {
+export default function NotSupportedLangTag({ lang }: { lang: Lang }) {
   const t = useTranslations(lang);
+
   return (
-    <BaseTag title={t("post.notSupportedLangDescription")}>
-      <span className="text-dracula-red-400">{t("post.notSupportedLang")}</span>
+    <BaseTag title={t("post.fallbackDescription")}>
+      <span className="text-dracula-red-400">{t("post.fallbackLabel")}</span>
     </BaseTag>
   );
 }

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -16,7 +16,7 @@ import GoTop from "@/components/ui/go-top.tsx";
 import { SITE } from "@/config";
 import { getLangFromUrl } from "@/utils/i18n";
 
-const { title, description, ogImageUrl, headerAsH1 = true } = Astro.props;
+const { title, headerAsH1 = true, ...metaProps } = Astro.props;
 const [lang] = getLangFromUrl(Astro.url.pathname);
 const pageTitle = title
   ? `${title} | ${SITE.title[lang]}`
@@ -25,12 +25,7 @@ const pageTitle = title
 
 <html lang={lang} class="scroll-smooth">
   <head>
-    <Meta
-      lang={lang}
-      description={description}
-      pageTitle={pageTitle}
-      ogImageUrl={ogImageUrl}
-    />
+    <Meta {...metaProps} lang={lang} pageTitle={pageTitle} />
     <Favicon />
     <RssLink lang={lang} />
     <Sitemap />

--- a/src/pages/[lang]/posts/[slug].astro
+++ b/src/pages/[lang]/posts/[slug].astro
@@ -2,56 +2,61 @@
 import BaseLayout from "@/layouts/base-layout.astro";
 import MarkdownPost from "@/components/ui/markdown-post.astro";
 import TocCard from "@/components/ui/cards/toc-card";
-import { classifyByLangs, getLangFromId, makeUniqueByLang } from "@/utils/post";
+import { classifyByLangs, resolvePostForLang } from "@/utils/post";
 import {
   getPostDescription,
   getPostHeadings,
   getPosts,
 } from "@/utils/post-cache";
-import { supportedLangs } from "@/utils/i18n";
+import { type Lang, supportedLangs } from "@/utils/i18n";
 
 export async function getStaticPaths() {
   const posts = await getPosts();
   const classified = classifyByLangs(posts);
   const paths = [];
 
-  for (const [slug, postsWithSameSlug] of classified) {
+  for (const [postSlug, postsWithSameSlug] of classified) {
     for (const lang of supportedLangs) {
-      const post = makeUniqueByLang(postsWithSameSlug, lang)[0];
+      const resolved = resolvePostForLang(postsWithSameSlug, lang);
       const [headings, description] = await Promise.all([
-        getPostHeadings(post),
-        getPostDescription(post),
+        getPostHeadings(resolved.post),
+        getPostDescription(resolved.post),
       ]);
       paths.push({
-        params: { lang, slug },
-        props: { post, headings, description },
+        params: { lang, slug: postSlug },
+        props: { resolved, headings, description },
       });
     }
   }
   return paths;
 }
 
-const { post, headings, description } = Astro.props;
-const { lang, slug } = Astro.params;
-const actualLangOfPost = getLangFromId(post.id);
-const ogImageUrlToUse =
-  post?.data.ogImageUrl || `/${actualLangOfPost}/og-images/${slug}.png`;
+const { resolved, headings, description } = Astro.props;
+const { post, requestedLang, actualLang, isFallback, availableLangs, slug } =
+  resolved;
+const canonicalLang = isFallback ? actualLang : requestedLang;
+const ogImageUrl = post.data.ogImageUrl || `/${actualLang}/og-images/${slug}.png`;
 ---
 
 <BaseLayout
-  title={post!.data.title}
+  title={post.data.title}
   description={description}
-  ogImageUrl={ogImageUrlToUse}
+  ogImageUrl={ogImageUrl}
   headerAsH1={false}
+  canonicalPath={`/${canonicalLang}/posts/${slug}`}
+  noindex={isFallback}
+  ogLocaleLang={actualLang}
+  alternateLangs={availableLangs}
+  alternatePath={(lang: Lang) => `/${lang}/posts/${slug}`}
 >
   <div class="relative">
     <div class="fixed top-10 right-10 hidden w-72 2xl:block">
-      <TocCard headings={headings} lang={lang} client:load />
+      <TocCard headings={headings} lang={requestedLang} client:load />
     </div>
     <MarkdownPost
       post={post}
-      lang={lang}
-      actualLang={actualLangOfPost}
+      lang={requestedLang}
+      actualLang={actualLang}
       headings={headings}
     />
   </div>

--- a/src/schemas/post.ts
+++ b/src/schemas/post.ts
@@ -26,6 +26,10 @@ export const PostSnapshotSchema = z.object({
   slug: z.string(),
   href: z.string(),
   date: z.string(),
+  requestedLang: z.string(),
+  actualLang: z.string(),
+  isFallback: z.boolean(),
+  availableLangs: z.array(z.string()),
 });
 
 export const RankedPostSnapshotSchema = PostSnapshotSchema.extend({

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -3,7 +3,7 @@ import { MISC } from "@/config";
 export const languages = {
   en: "EN",
   zh: "中",
-};
+} as const;
 
 export const defaultLang: Lang = "en";
 
@@ -41,9 +41,8 @@ export const ui = {
     "post.newlyUpdatedMsg": `Updated within ${MISC.dateTag.daysToBeGreen} days`,
     "post.oldPostWarningMsg": `Last update over ${MISC.dateTag.daysToBeRed} days ago`,
     "post.license": "Licensed under",
-    "post.notSupportedLang": "Language not supported",
-    "post.notSupportedLangDescription":
-      "Sorry, your language is unavailable for this post.",
+    "post.fallbackLabel": "No English version",
+    "post.fallbackDescription": "Showing Chinese content instead",
   },
   zh: {
     loadMore: "加载更多",
@@ -75,29 +74,45 @@ export const ui = {
     "post.newlyUpdatedMsg": `更新于 ${MISC.dateTag.daysToBeGreen} 日内`,
     "post.oldPostWarningMsg": `更新于 ${MISC.dateTag.daysToBeRed} 日前`,
     "post.license": "许可证",
-    "post.notSupportedLang": "语言暂不支持",
-    "post.notSupportedLangDescription": "抱歉，此文章暂不支持您的语言。",
+    "post.fallbackLabel": "暂无中文版本",
+    "post.fallbackDescription": "正在显示英文内容",
   },
 } as const;
 
 export type Lang = keyof typeof languages;
 export const supportedLangs = Object.keys(languages) as Lang[];
 
-export function useTranslatedPath(lang: keyof typeof ui) {
-  return function translatePath(path: string, l: string = lang) {
-    return `/${l}${path}`;
+export function isLang(lang: unknown): lang is Lang {
+  return typeof lang === "string" && lang in languages;
+}
+
+function normalizePath(path: string) {
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+export function getLocalizedPath(path: string, lang: Lang) {
+  return `/${lang}${normalizePath(path)}`;
+}
+
+export function useTranslatedPath(lang: Lang) {
+  return function translatePath(path: string, l: Lang = lang) {
+    return getLocalizedPath(path, l);
   };
 }
 
-export function getLangFromUrl(url: string): [Lang, string] {
-  const [, lang, ...rest] = url.split("/");
-  const urlWithoutLang = rest.join("/");
-  if (lang in ui) return [lang as Lang, urlWithoutLang];
-  return [defaultLang as Lang, urlWithoutLang];
+export function getLangFromUrl(pathname: string): [Lang, string] {
+  const segments = pathname.split("/").filter(Boolean);
+  const [firstSegment, ...restSegments] = segments;
+
+  if (isLang(firstSegment)) {
+    return [firstSegment, restSegments.join("/")];
+  }
+
+  return [defaultLang, segments.join("/")];
 }
 
 export function useTranslations(lang: Lang) {
   return function t(key: keyof (typeof ui)[typeof lang]) {
-    return ui[lang][key] || ui[defaultLang][key];
+    return ui[lang][key] ?? ui[defaultLang][key];
   };
 }

--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -1,5 +1,4 @@
-import type { Post, Slug } from "@/schemas/post";
-import type { PostSnapshot } from "@/schemas/post";
+import type { Post, PostSnapshot, Slug } from "@/schemas/post";
 import { type Lang, defaultLang } from "@/utils/i18n";
 import { getDescFromMdString } from "@/utils/markdown";
 
@@ -9,11 +8,8 @@ export const getLangFromId = (id: string): Lang => {
 };
 
 export const getSlugFromId = (id: string): Slug => {
-  if (!id.includes("/")) {
-    return id;
-  }
-  const [, ...rest] = id.split("/");
-  return rest.join("/");
+  const separatorIndex = id.indexOf("/");
+  return separatorIndex === -1 ? id : id.slice(separatorIndex + 1);
 };
 
 /**
@@ -25,38 +21,76 @@ export const classifyByLangs = (posts: Post[]) => {
   const map = new Map<Slug, Post[]>();
   for (const post of posts) {
     const slug = getSlugFromId(post.id);
-    map.set(slug, [...(map.get(slug) || []), post]);
+    const postsWithSlug = map.get(slug);
+
+    if (postsWithSlug) {
+      postsWithSlug.push(post);
+    } else {
+      map.set(slug, [post]);
+    }
   }
   return map;
 };
 
-/**
- * Returns a list of unique posts by language, in the order of:
- *
- * 1. The post with the expected language.
- * 2. The post with the default language.
- * 3. The post with the first language in the supported languages list.
- *
- * @param posts - A list of posts.
- * @param expectedLang - The expected language.
- * @returns The list of unique posts.
- */
-export const makeUniqueByLang = (posts: Post[], expectedLang: Lang) => {
-  const classified = classifyByLangs(posts);
-
-  return Array.from(classified.keys()).map((slug) => {
-    const signlePostMultipleLangs = classified.get(slug)!;
-    return (
-      signlePostMultipleLangs.find(
-        (version) => getLangFromId(version.id) === expectedLang
-      ) ||
-      signlePostMultipleLangs.find(
-        (version) => getLangFromId(version.id) === defaultLang
-      ) ||
-      signlePostMultipleLangs[0]
-    );
-  });
+export type ResolvedPost = {
+  post: Post;
+  requestedLang: Lang;
+  actualLang: Lang;
+  slug: Slug;
+  isFallback: boolean;
+  availableLangs: Lang[];
 };
+
+/**
+ * Resolves one logical post for the requested language, in the order of:
+ *
+ * 1. The post with the requested language.
+ * 2. The post with the default language.
+ * 3. The first available post version.
+ */
+export const resolvePostForLang = (
+  postsWithSameSlug: Post[],
+  requestedLang: Lang
+): ResolvedPost => {
+  if (postsWithSameSlug.length === 0) {
+    throw new Error("Cannot resolve post from an empty post list");
+  }
+
+  const findPostByLang = (lang: Lang) =>
+    postsWithSameSlug.find((version) => getLangFromId(version.id) === lang);
+  const post =
+    findPostByLang(requestedLang) ??
+    findPostByLang(defaultLang) ??
+    postsWithSameSlug[0];
+  const actualLang = getLangFromId(post.id);
+
+  return {
+    post,
+    requestedLang,
+    actualLang,
+    slug: getSlugFromId(post.id),
+    isFallback: actualLang !== requestedLang,
+    availableLangs: postsWithSameSlug.map((version) =>
+      getLangFromId(version.id)
+    ),
+  };
+};
+
+export const resolveUniquePostsByLang = (
+  posts: Post[],
+  requestedLang: Lang
+): ResolvedPost[] => {
+  const classified = classifyByLangs(posts);
+  return Array.from(classified.values()).map((postsWithSameSlug) =>
+    resolvePostForLang(postsWithSameSlug, requestedLang)
+  );
+};
+
+/** Compatibility layer returning only resolved post entries. */
+export const makeUniqueByLang = (posts: Post[], expectedLang: Lang) =>
+  resolveUniquePostsByLang(posts, expectedLang).map(
+    (resolved) => resolved.post
+  );
 
 /**
  * Gets the snapshots of posts. They are unique to languages, and sorted by date.
@@ -69,18 +103,25 @@ export const getSnapshots = async (
   getPostDescription: PostDescriptionGetter = (post) =>
     getDescFromMdString(post.body)
 ): Promise<PostSnapshot[]> => {
-  const uniquePosts = makeUniqueByLang(posts, expectedLang);
-  const sorted = [...uniquePosts].sort((a, b) => {
-    const dateA = a.data.updated || a.data.date;
-    const dateB = b.data.updated || b.data.date;
+  const resolvedPosts = resolveUniquePostsByLang(posts, expectedLang);
+  const sorted = [...resolvedPosts].sort((a, b) => {
+    const dateA = a.post.data.updated || a.post.data.date;
+    const dateB = b.post.data.updated || b.post.data.date;
     return dateB.getTime() - dateA.getTime();
   });
   return Promise.all(
-    sorted.map(async (post) => {
-      const slug = getSlugFromId(post.id);
+    sorted.map(async (resolved) => {
+      const {
+        post,
+        requestedLang,
+        actualLang,
+        slug,
+        isFallback,
+        availableLangs,
+      } = resolved;
 
       return {
-        href: `/${expectedLang}/posts/${slug}`,
+        href: `/${requestedLang}/posts/${slug}`,
         title: post.data.title,
         date: getCloserFormattedDate(
           post.data.updated?.toISOString(),
@@ -89,6 +130,10 @@ export const getSnapshots = async (
         description: await getPostDescription(post),
         slug,
         tags: Array.from(getUniqueLowerCaseTagMap(post.data.tags).keys()),
+        requestedLang,
+        actualLang,
+        isFallback,
+        availableLangs,
       };
     })
   );
@@ -111,10 +156,7 @@ export const getUniqueLowerCaseTagMap = (
 };
 
 /**
- * Returns the closer date from two date strings.
- * @param dateStringA - The first date string.
- * @param dateStringB - The second date string.
- * @returns The closest date to the current date.
+ * Returns the later of two date strings formatted as YYYY-MM-DD.
  */
 export const getCloserFormattedDate = (
   dateStringA?: string,


### PR DESCRIPTION
## Summary
- add language-aware post fallback handling and fallback badges
- add canonical, noindex, alternate language, and Open Graph locale metadata
- include fallback metadata in post snapshots for listing/search UI

## Verification
- pnpm build
- pnpm lint
- pnpm format:check